### PR TITLE
[FIX] emotion typescript integration

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
+    "jsxImportSource": "@emotion/react",
 
     /* Linting */
     "strict": true,


### PR DESCRIPTION
emotion의 jsx factory를 사용하도록 수정했습니다. 사실 noEmit이 설정되어 있고 vite가 내부적으로 babel을 써서 트랜스파일할거라 emotion의 babel plugin이 설정되어있는 한 별 문제 없을 텐데 보기에 불편해서 수정합니다.